### PR TITLE
fix: URL import cancel / error label / tree error logging (Phase 18)

### DIFF
--- a/internal/handler/tree.go
+++ b/internal/handler/tree.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path"
@@ -127,7 +129,9 @@ func walkTree(dirAbs, dirRel string, depth int) ([]treeNode, bool, error) {
 			grand, hasGrand, err := walkTree(childAbs, childRel, depth-1)
 			if err != nil {
 				// One unreadable subdir shouldn't fail the whole tree;
-				// surface as "no children" with a debug log path.
+				// surface as "no children" but log so operators can trace
+				// permission/IO problems instead of seeing silent blanks.
+				slog.Debug("tree walk: subdir unreadable", "path", childAbs, "err", err)
 				node.Children = []treeNode{}
 				node.HasChildren = false
 			} else {
@@ -135,7 +139,10 @@ func walkTree(dirAbs, dirRel string, depth int) ([]treeNode, bool, error) {
 				node.HasChildren = hasGrand
 			}
 		} else {
-			has, _ := dirHasSubdirs(childAbs)
+			has, err := dirHasSubdirs(childAbs)
+			if err != nil {
+				slog.Debug("tree walk: has-children probe failed", "path", childAbs, "err", err)
+			}
 			node.HasChildren = has
 			if has {
 				node.Children = nil // not loaded — UI lazy-fetches on expand
@@ -150,7 +157,9 @@ func walkTree(dirAbs, dirRel string, depth int) ([]treeNode, bool, error) {
 
 // dirHasSubdirs probes whether dirAbs contains at least one non-hidden
 // subdirectory. Used at the depth boundary to set HasChildren without
-// loading grandchildren.
+// loading grandchildren. Returns (false, err) on a real read error so
+// the caller can log it — previously any error, including IO failures,
+// was mapped to (false, nil) and hid problems from operators.
 func dirHasSubdirs(dirAbs string) (bool, error) {
 	f, err := os.Open(dirAbs)
 	if err != nil {
@@ -170,7 +179,10 @@ func dirHasSubdirs(dirAbs string) (bool, error) {
 			}
 		}
 		if err != nil {
-			return false, nil // io.EOF or end — no subdir found
+			if err == io.EOF {
+				return false, nil
+			}
+			return false, err
 		}
 	}
 }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -125,9 +125,9 @@
 - [x] S5: 수동 E2E 검증 — plan.md Phase 17 S5의 10개 시나리오 통과 (docker compose up --build 후 브라우저 확인 완료)
 
 ## Phase 18 — 리뷰 후속 (review fixes, `feature/review-fixes`)
-- [ ] F-4 (high): URL import AbortController — `urlAbort = new AbortController()`를 `submitURLImport` 시작 시 생성, `fetch(..., { signal: urlAbort.signal })`, `closeURLModal`에서 `urlAbort?.abort()`, `AbortError` 수신 시 row 상태를 "취소됨"으로 표시. 패턴은 convert(`convertAbort`) 그대로 복사.
-- [ ] F-5 (high): URL error label에서 하드코드 수치 제거 — `too_large: '크기 상한 초과'`, `download_timeout: '다운로드 타임아웃'`로 변경. 설정 값은 런타임에 PATCH로 바뀌므로 라벨에 박으면 틀리게 된다.
-- [ ] F-6 (medium): `internal/handler/tree.go` 에러 로깅 — `walkTree`의 err 무시 지점(line 126 부근)과 `dirHasSubdirs`의 read 실패 지점에 `slog.Debug("tree walk failed", "path", ..., "err", err)` 추가. 주석(`with a debug log path`) 약속 이행.
+- [x] F-4 (high): URL import AbortController — `submitURLImport`에서 `urlAbort = new AbortController()` 생성 + fetch에 `signal` 전달, `closeURLModal`에서 submitting 상태면 `urlAbort.abort()`, catch에서 `AbortError` 무시 + finally에서 `urlAbort = null`. `app.js?v=18` bump.
+- [x] F-5 (high): URL error label에서 하드코드 수치 제거 — `too_large: '크기 상한 초과'`, `download_timeout: '다운로드 타임아웃'`로 변경.
+- [x] F-6 (medium): `tree.go` 에러 로깅 — walkTree subdir err 및 dirHasSubdirs read err 지점에 `slog.Debug`, `dirHasSubdirs`는 io.EOF만 정상 종료 나머지는 err 반환. `log/slog`·`io` import 추가. 기존 Tree 테스트 7 + ErrorCases 7 subcase 전부 통과.
 
 ### 하드닝 대기 (record-only)
 - [ ] H-SYMLINK: `media.SafePath` 심볼릭 링크 방어 — 현재 `filepath.Join` 순수 문자열 검사라 `/data` 내부에 symlink가 심어지면 루트 탈출 가능. `filepath.EvalSymlinks`를 SafePath 말미에 추가하고 결과도 다시 prefix 검증. 위협 모델(단일 사용자 LAN, upload는 일반 파일만 생성)상 실제 공격 벡터는 좁지만 심층 방어 차원에서 개선 가치 있음. 별도 phase로 분리 — read-only 경로(browse/tree/stream/thumb)부터 적용, upload/rename 후 재검증 여부 결정 필요.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -123,3 +123,11 @@
 - [x] S3: `handleSettings` (`GET`/`PATCH` `/api/settings`) — GET은 `Snapshot()` JSON, PATCH는 `DisallowUnknownFields` + `Update` → `RangeError`면 `400 {"error":"out_of_range","field":"..."}`, 그 외 실패는 `500 write_failed`, store nil(test harness)이면 `500 settings disabled`. 테스트 8개 (GET defaults, PATCH round-trip, Out-of-range 4 subcase, Malformed JSON, Unknown field, LandsInImportURL, MethodNotAllowed 3 subcase)
 - [x] S4: 프론트엔드 — `index.html`에 헤더 `⚙` 버튼 + `#settings-modal` (MiB number input, 분 number input, `.settings-hint` GiB 환산, error p, 저장/취소), URL 모달 hint를 "용량/타임아웃은 ⚙ 설정에서 조정"으로 교체, `app.js?v=16` bump, `style.css` `.settings-btn`·`.settings-field`·`.settings-label`·`.settings-hint` 규칙, `app.js`에 DOM refs 8개 + `SETTINGS_MAX_MIB_MIN/MAX`·`SETTINGS_TIMEOUT_MIN/MAX`·`SETTINGS_FIELD_LABELS` + `openSettingsModal`/`closeSettingsModal`/`updateSettingsMaxHint`/`submitSettings`/`showSettingsError`, 키보드 Escape/Enter + click-outside 지원
 - [x] S5: 수동 E2E 검증 — plan.md Phase 17 S5의 10개 시나리오 통과 (docker compose up --build 후 브라우저 확인 완료)
+
+## Phase 18 — 리뷰 후속 (review fixes, `feature/review-fixes`)
+- [ ] F-4 (high): URL import AbortController — `urlAbort = new AbortController()`를 `submitURLImport` 시작 시 생성, `fetch(..., { signal: urlAbort.signal })`, `closeURLModal`에서 `urlAbort?.abort()`, `AbortError` 수신 시 row 상태를 "취소됨"으로 표시. 패턴은 convert(`convertAbort`) 그대로 복사.
+- [ ] F-5 (high): URL error label에서 하드코드 수치 제거 — `too_large: '크기 상한 초과'`, `download_timeout: '다운로드 타임아웃'`로 변경. 설정 값은 런타임에 PATCH로 바뀌므로 라벨에 박으면 틀리게 된다.
+- [ ] F-6 (medium): `internal/handler/tree.go` 에러 로깅 — `walkTree`의 err 무시 지점(line 126 부근)과 `dirHasSubdirs`의 read 실패 지점에 `slog.Debug("tree walk failed", "path", ..., "err", err)` 추가. 주석(`with a debug log path`) 약속 이행.
+
+### 하드닝 대기 (record-only)
+- [ ] H-SYMLINK: `media.SafePath` 심볼릭 링크 방어 — 현재 `filepath.Join` 순수 문자열 검사라 `/data` 내부에 symlink가 심어지면 루트 탈출 가능. `filepath.EvalSymlinks`를 SafePath 말미에 추가하고 결과도 다시 prefix 검증. 위협 모델(단일 사용자 LAN, upload는 일반 파일만 생성)상 실제 공격 벡터는 좁지만 심층 방어 차원에서 개선 가치 있음. 별도 phase로 분리 — read-only 경로(browse/tree/stream/thumb)부터 적용, upload/rename 후 재검증 여부 결정 필요.

--- a/web/app.js
+++ b/web/app.js
@@ -661,6 +661,7 @@ const URL_ERROR_LABELS = {
 
 let urlSubmitting = false;
 let urlAnySucceeded = false;
+let urlAbort = null;
 
 urlImportBtn.addEventListener('click', openURLModal);
 urlCancelBtn.addEventListener('click', closeURLModal);
@@ -685,6 +686,11 @@ function openURLModal() {
 }
 
 function closeURLModal() {
+  if (urlSubmitting && urlAbort) {
+    // Client disconnect flows to the handler as r.Context() cancel → backend
+    // stops the current Fetch and skips remaining URLs in the batch.
+    urlAbort.abort();
+  }
   urlModal.classList.add('hidden');
   if (urlAnySucceeded) {
     urlAnySucceeded = false;
@@ -719,12 +725,14 @@ async function submitURLImport() {
   urlSubmitting = true;
   urlConfirmBtn.disabled = true;
   urlConfirmBtn.textContent = '가져오는 중...';
+  urlAbort = new AbortController();
 
   try {
     const res = await fetch('/api/import-url?path=' + encodeURIComponent(currentPath), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
       body: JSON.stringify({ urls }),
+      signal: urlAbort.signal,
     });
     if (!res.ok) {
       let msg = '';
@@ -736,9 +744,12 @@ async function submitURLImport() {
     }
     await consumeSSE(res, handleSSEEvent);
   } catch (e) {
-    showURLError('요청 실패: ' + e.message);
+    if (e.name !== 'AbortError') {
+      showURLError('요청 실패: ' + e.message);
+    }
   } finally {
     urlSubmitting = false;
+    urlAbort = null;
     urlConfirmBtn.disabled = false;
     urlConfirmBtn.textContent = '가져오기';
   }

--- a/web/app.js
+++ b/web/app.js
@@ -641,15 +641,18 @@ function showFolderError(msg) {
 }
 
 // ── URL Import ────────────────────────────────────────────────────────────────
+// Labels intentionally omit specific byte/time limits because those are
+// configurable at runtime via /api/settings — hardcoding numbers here made
+// the UI lie when the user had bumped the cap or timeout.
 const URL_ERROR_LABELS = {
   missing_content_length: 'Content-Length 헤더 없음',
-  too_large: '2GB 초과',
+  too_large: '크기 상한 초과',
   unsupported_content_type: '지원하지 않는 미디어 타입',
   invalid_scheme: '지원하지 않는 스킴',
   invalid_url: '잘못된 URL',
   http_error: 'HTTP 응답 에러',
   connect_timeout: '연결 타임아웃',
-  download_timeout: '다운로드 타임아웃 (10분)',
+  download_timeout: '다운로드 타임아웃',
   tls_error: 'TLS 검증 실패',
   too_many_redirects: '리다이렉트 과다',
   network_error: '네트워크 오류',

--- a/web/index.html
+++ b/web/index.html
@@ -163,6 +163,6 @@
     </div>
   </div>
 
-  <script src="/app.js?v=16"></script>
+  <script src="/app.js?v=17"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -163,6 +163,6 @@
     </div>
   </div>
 
-  <script src="/app.js?v=17"></script>
+  <script src="/app.js?v=18"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
코드 리뷰에서 발견된 6개 지적 중 우선순위 높은 3건을 처리. 1번(SafePath symlink)은 위협 모델상 후순위라 `tasks/todo.md`의 **H-SYMLINK** 하드닝 항목으로 기록만 해 둠. 3번(HTTPS에도 insecure_http 경고)은 Go switch 시맨틱 오독으로 드러나 사실상 폐기.

- **F-4 (high)** URL import 취소 불가 → `AbortController` 도입 (convert 패턴 이식). 모달을 닫으면 진행 중 fetch 중단, 백엔드(`handleImportURL`)가 `r.Context()` 취소로 받아 현재 Fetch 중단 + 남은 URL 건너뜀.
- **F-5 (high)** 에러 라벨의 하드코드 수치(`2GB 초과`, `10분`)가 런타임 PATCH로 바뀌는 기본값(10 GiB / 30분)과 어긋남 → 수치 제거 (`크기 상한 초과`, `다운로드 타임아웃`).
- **F-6 (medium)** `tree.go`의 조용한 에러 swallow → `slog.Debug`로 경로·원인 기록, `dirHasSubdirs`는 io.EOF만 정상 종료하고 나머지는 호출자에게 반환.

## Test plan
- [x] `go test ./...` 전체 그린 (6 packages)
- [x] `go test ./internal/handler -run Tree` Tree 7 + ErrorCases 7 subcase 통과
- [x] URL import 모달 열어서 다운로드 중 닫기 → DevTools Network에서 요청 cancelled 확인
- [x] URL 설정 10240 MiB로 올린 뒤 큰 파일 import 실패 → 에러 라벨에 수치 없이 "크기 상한 초과" 표시
- [x] 권한 없는 서브디렉터리 포함 폴더에서 `GET /api/tree` → 서버 로그에 `tree walk: subdir unreadable` DEBUG 라인 확인
- [x] Docker 재빌드 후 `app.js?v=18` 로드 + 기존 기능(업로드/스트리밍/변환/HLS) 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)