### PR TITLE
feat(urlfetch): block private network imports

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -293,16 +293,17 @@ TS 파일은 현재 `/api/stream` 요청 시마다 ffmpeg로 실시간 리먹싱
   2. HTTP는 허용하되 `warnings`에 `"insecure_http"` 추가 (다운로드는 진행)
   3. HTTPS는 표준 TLS 인증서 검증 (자체서명 거부)
   4. 리다이렉트 최대 5회 추적 (스킴은 매 hop마다 재검증)
-  5. 요청 시 `Authorization` 등 인증 헤더 자동 첨부 안 함
-  6. 응답 헤더 검증:
+  5. DNS 해석 결과가 loopback/private/link-local/multicast/unspecified IP이면 거부 (`error: "private_network"`). 최초 요청과 redirect 이후 실제 dial 대상 모두에 적용하며, HLS master playlist의 선택 variant URL도 ffmpeg 실행 전에 동일하게 검증한다. 단, ffmpeg는 HLS variant/segment fetch 시 자체 DNS 해석을 수행하므로 DNS rebinding을 받는 호스트에 대해서는 우회될 수 있다 — §9 Boundaries 참조.
+  6. 요청 시 `Authorization` 등 인증 헤더 자동 첨부 안 함
+  7. 응답 헤더 검증:
      - `Content-Type`이 위 허용 목록에 없으면 거부 (`error: "unsupported_content_type"`)
      - **HLS 분기** (§2.6.1): Content-Type이 HLS 플레이리스트이거나, URL 경로가 `.m3u8`로 끝나고 Content-Type이 `text/plain` / `application/octet-stream` / 파싱 불가 → HLS 흐름으로 이탈하고 이하 §2.6 검증은 건너뜀
      - `Content-Length` 헤더가 있고 설정값 `url_import_max_bytes`(§2.7) 초과면 다운로드 시작 전 거부 (`error: "too_large"`)
      - `Content-Length` 헤더 없어도 다운로드 진행 (아래 누적 카운터로 런타임 보호)
-  7. 임시 파일에 스트리밍 저장
-  8. 다운로드 중 누적 바이트가 `url_import_max_bytes` 초과 시 즉시 중단 + 임시 파일 삭제 (`error: "too_large"`)
-  9. 검증 통과 시 임시 파일 → 최종 경로로 atomic rename
-  10. 이미지·동영상 성공 시 `.thumb/{name}.jpg` 섬네일 비동기 생성 (음악은 생략)
+  8. 임시 파일에 스트리밍 저장
+  9. 다운로드 중 누적 바이트가 `url_import_max_bytes` 초과 시 즉시 중단 + 임시 파일 삭제 (`error: "too_large"`)
+  10. 검증 통과 시 임시 파일 → 최종 경로로 atomic rename
+  11. 이미지·동영상 성공 시 `.thumb/{name}.jpg` 섬네일 비동기 생성 (음악은 생략)
 - [ ] **진행 이벤트 (SSE)**: URL당 최소 `start` → `done` 또는 `start` → `error`. 큰 파일은 중간에 `progress` 이벤트를 주기적으로 방출 (§5.1.1). 배치 단위로는 응답 헤더 직후 `register` 이벤트 1회(jobId 부여) → `queued` 이벤트 1회 → URL 단위 이벤트들 → `summary` 이벤트로 종료한다 (§5.1).
 - [ ] **타임아웃**: 연결 10초 + 전체 다운로드는 설정값 `url_import_timeout_seconds`(§2.7, 기본 30분, 개별 URL 단위). 초과 시 `error: "download_timeout"`
 - [ ] **배치 직렬화**: 서버는 `Handler.importSem`(size-1 채널 세마포어)로 `POST /api/import-url`을 **프로세스 전역에서 한 번에 한 배치씩 순차 처리**한다. 동시에 여러 클라이언트(또는 같은 사용자가 모달 재오픈으로 추가한 두 번째 배치)가 POST를 보내면, 응답 헤더는 즉시 가고 `queued` 이벤트가 곧바로 송출되지만, 후속 `start` 이벤트는 앞선 배치가 끝날 때까지 대기한다. 세마포어 wait는 **잡 컨텍스트(`Job.Ctx()`)와 함께 select** 되므로, 잡이 명시적 취소되면 미획득 상태로 즉시 종료된다. 클라이언트 disconnect는 잡을 취소하지 않는다 — 아래 *백그라운드 진행*.
@@ -646,6 +647,7 @@ file_server/
   - `"connect_timeout"` — 연결 10초 초과
   - `"download_timeout"` — `url_import_timeout_seconds`(§2.7) 초과
   - `"too_many_redirects"` — 5회 초과
+  - `"private_network"` — loopback/private/link-local/multicast/unspecified IP 대상 차단
   - `"tls_error"` — TLS 인증서 검증 실패
   - `"http_error"` — 4xx/5xx 응답
   - `"unsupported_content_type"` — 허용 Content-Type 목록 밖
@@ -936,6 +938,7 @@ volumes:
   - Content-Length 누락 + 본문이 설정 cap 초과 → `error: "too_large"` (런타임) + 임시 파일 정리 확인
   - `Content-Type: text/html` → `error: "unsupported_content_type"` 이벤트
   - HTTP URL → `done` + `warnings: ["insecure_http"]`
+  - private network URL(`127.0.0.1`, `192.168.0.0/16` 등) → `error: "private_network"`
   - URL 확장자와 Content-Type 불일치 → 확장자 교체 + `warnings: ["extension_replaced"]`
   - 부분 실패: 3개 URL 혼합 → 각 URL당 `done`/`error` 1개씩 + `summary` 1개
   - 리다이렉트 6회 → `error: "too_many_redirects"`
@@ -1014,4 +1017,4 @@ volumes:
 - HLS live stream은 설정값 `url_import_timeout_seconds`(§2.7, 기본 30분) 또는 `url_import_max_bytes`(기본 10 GiB) 시점에 강제 종료 — 긴 live 컨텐츠는 끝까지 기록되지 않는다. 명시적 live 감지·분기는 없음. 필요하면 UI에서 값을 키워 재시도 가능.
 - HLS 다운로드는 `start` 이벤트에 `total`이 없어 클라이언트 프로그래스 바는 indeterminate(수치 없이 애니메이션) 표시가 필요. 기존 UI가 `total` 없음을 허용하는지 §2.5 모달 구현 시 확인.
 - HLS 임시 파일 TOCTOU: `os.CreateTemp` → `Close` → ffmpeg `-y` 재오픈 사이에 동일 경로 write 권한을 가진 로컬 프로세스가 symlink로 대체하는 이론적 race 창이 존재. 단일 사용자 자기-호스팅 모델에서 `destDir` write 권한자는 사용자 본인이므로 실제 위협 없음 — 다중 사용자 배포로 확장 시 `O_NOFOLLOW` 또는 ffmpeg stdout 파이프 방식 재검토 필요.
-- URL import SSRF 정책(약함)은 설계상 선택. 사설 IP(`127.0.0.1`, `10.x`, `192.168.x`, `169.254.169.254` 등)은 호스트 검증 없이 그대로 fetch 허용 — LAN 미디어 서버 호출 등 정상 케이스 허용이 우선. VPS/다중 사용자 호스팅으로 확장 시 cloud metadata endpoint(`169.254.169.254`)는 무조건 차단 권장.
+- URL import SSRF 정책은 일반 HTTP 다운로드 경로에서 DNS 해석 결과를 검사하고 해당 IP literal로 dial해 DNS rebinding을 차단한다. HLS 경로는 ffmpeg가 variant/segment URL을 직접 fetch하면서 자체 DNS 해석을 수행하므로, Go-side variant URL 사전 검증과 ffmpeg protocol whitelist만으로는 DNS rebinding을 완전히 차단하지 못한다. 단일 사용자 LAN 모델의 acknowledged risk로 둔다. 강한 HLS SSRF 방어가 필요하면 Go-side playlist/segment fetch 또는 segment URL 재작성 설계를 별도 구현해야 한다.

--- a/internal/handler/files_test.go
+++ b/internal/handler/files_test.go
@@ -68,7 +68,8 @@ func TestUpload(t *testing.T) {
 func TestUploadResponseFields(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	h := Register(mux, root, root, nil)
+	defer h.Close()
 
 	upload := func(filename string, content []byte) *httptest.ResponseRecorder {
 		body := &bytes.Buffer{}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -45,6 +45,18 @@ func WithServerCtx(ctx context.Context) Option {
 	}
 }
 
+// WithURLClient overrides the URL import HTTP client. Production uses the
+// default protected urlfetch client; tests can inject a localhost-capable
+// client without widening the production path.
+func WithURLClient(client *http.Client) Option {
+	return func(h *Handler) {
+		if client == nil {
+			return
+		}
+		h.urlClient = client
+	}
+}
+
 // Register wires all API routes. settingsStore may be nil in tests that do
 // not exercise URL import or /api/settings — callers that pass nil get the
 // hard-coded Default() values from settings. Pass WithServerCtx in production

--- a/internal/handler/import_url_jobs_test.go
+++ b/internal/handler/import_url_jobs_test.go
@@ -38,7 +38,7 @@ func getJobs(t *testing.T, mux *http.ServeMux) listJobsBody {
 func TestListJobs_Empty(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	body := getJobs(t, mux)
@@ -50,7 +50,7 @@ func TestListJobs_Empty(t *testing.T) {
 func TestListJobs_ActiveAndFinished(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	// Pre-filled placeholder jobs need explicit termination so Close does
 	// not block the full WaitAll budget.
 	defer func() {
@@ -90,7 +90,7 @@ func TestListJobs_ActiveAndFinished(t *testing.T) {
 func TestListJobs_MethodNotAllowed(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	// DELETE is also a valid method on /jobs (J5 ?status=finished) so it
@@ -109,7 +109,7 @@ func TestListJobs_MethodNotAllowed(t *testing.T) {
 func TestSubscribeJob_NotFound(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/import-url/jobs/imp_unknown/events", nil)
@@ -123,7 +123,7 @@ func TestSubscribeJob_NotFound(t *testing.T) {
 func TestSubscribeJob_FinishedReturnsSnapshotAndCloses(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	job, err := h.registry.Create("/", []string{"https://placeholder/x"})
@@ -183,7 +183,7 @@ func TestSubscribeJob_ActiveReceivesLiveEvents(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	// First subscriber: the POST itself. We only need it to expose the jobId.
@@ -224,7 +224,7 @@ func TestSubscribeJob_ActiveReceivesLiveEvents(t *testing.T) {
 func TestSubscribeJob_BadRoute(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	job, err := h.registry.Create("/", []string{"u"})
@@ -237,7 +237,7 @@ func TestSubscribeJob_BadRoute(t *testing.T) {
 		path string
 		want int
 	}{
-		{"/api/import-url/jobs/" + job.ID, http.StatusMethodNotAllowed}, // bare id only allows DELETE
+		{"/api/import-url/jobs/" + job.ID, http.StatusMethodNotAllowed},           // bare id only allows DELETE
 		{"/api/import-url/jobs/" + job.ID + "/events/extra", http.StatusNotFound}, // suffix junk
 		{"/api/import-url/jobs/" + job.ID + "/unknown", http.StatusNotFound},      // typo'd action
 		{"/api/import-url/jobs/", http.StatusNotFound},                            // empty id
@@ -257,7 +257,7 @@ func TestSubscribeJob_BadRoute(t *testing.T) {
 func TestSubscribeJob_MethodNotAllowed(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	job, err := h.registry.Create("/", []string{"u"})
@@ -286,7 +286,7 @@ func TestCancelJob_Batch(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	// Hold the import semaphore so the batch we cancel never reaches the
@@ -339,7 +339,7 @@ func TestCancelJob_PerURL_Running(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	rec, wait := postImportStreaming(context.Background(), t, mux,
@@ -409,7 +409,7 @@ func TestCancelJob_PerURL_Pending(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	rec, wait := postImportStreaming(context.Background(), t, mux,
@@ -466,7 +466,7 @@ func TestCancelJob_PerURL_Pending_ThenBatch(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	rec, wait := postImportStreaming(context.Background(), t, mux,
@@ -603,7 +603,7 @@ func TestCancelJob_PerURL_Pending_ThenBatch_PreSemaphore(t *testing.T) {
 func TestCancelJob_NotFound(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	req := httptest.NewRequest(http.MethodPost,
@@ -618,7 +618,7 @@ func TestCancelJob_NotFound(t *testing.T) {
 func TestCancelJob_AlreadyFinished(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	job, err := h.registry.Create("/", []string{"u"})
@@ -639,7 +639,7 @@ func TestCancelJob_AlreadyFinished(t *testing.T) {
 func TestCancelJob_BadIndex(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	job, err := h.registry.Create("/", []string{"u"})
@@ -670,7 +670,7 @@ func TestCancelJob_BadIndex(t *testing.T) {
 func TestDeleteJob_Active(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	job, err := h.registry.Create("/", []string{"u"})
@@ -693,7 +693,7 @@ func TestDeleteJob_Active(t *testing.T) {
 func TestDeleteJob_Finished(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	job, err := h.registry.Create("/", []string{"u"})
@@ -716,7 +716,7 @@ func TestDeleteJob_Finished(t *testing.T) {
 func TestDeleteJob_NotFound(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/import-url/jobs/imp_unknown", nil)
@@ -730,7 +730,7 @@ func TestDeleteJob_NotFound(t *testing.T) {
 func TestDeleteFinishedJobs(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer func() {
 		// Non-terminated placeholders need explicit cleanup so Close does
 		// not consume the WaitAll budget.
@@ -787,4 +787,3 @@ func TestDeleteFinishedJobs(t *testing.T) {
 		t.Errorf("active count = %d, want 1 (one job was queued)", len(active))
 	}
 }
-

--- a/internal/handler/import_url_test.go
+++ b/internal/handler/import_url_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/chang/file_server/internal/importjob"
+	"github.com/chang/file_server/internal/urlfetch"
 )
 
 // jpegBody is a minimal JFIF byte sequence — enough for tests; we don't decode it.
@@ -25,6 +26,11 @@ var jpegBody = []byte{
 	0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00,
 	0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
 	0xFF, 0xD9,
+}
+
+func registerImportTest(mux *http.ServeMux, root string) *Handler {
+	return Register(mux, root, root, nil,
+		WithURLClient(urlfetch.NewClient(urlfetch.AllowPrivateNetworks())))
 }
 
 // newHoldReleaseOrigin returns an origin that blocks any request whose URL
@@ -107,6 +113,28 @@ func postImport(t *testing.T, mux *http.ServeMux, path string, urls []string) *h
 	return rw
 }
 
+func TestImportURL_DefaultClientBlocksPrivateNetwork(t *testing.T) {
+	root := t.TempDir()
+	mux := http.NewServeMux()
+	h := Register(mux, root, root, nil)
+	defer h.Close()
+
+	rw := postImport(t, mux, "/", []string{"http://127.0.0.1/photo.jpg"})
+	if rw.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rw.Code, rw.Body.String())
+	}
+	events := parseSSEEvents(t, rw.Body.String())
+	var gotPrivate bool
+	for _, ev := range events {
+		if ev["phase"] == "error" && ev["error"] == "private_network" {
+			gotPrivate = true
+		}
+	}
+	if !gotPrivate {
+		t.Fatalf("events = %+v, want private_network error", events)
+	}
+}
+
 // parseSSEEvents splits an SSE response body into JSON payloads. It expects
 // each event to be a single `data: {json}\n\n` frame (no event names, no IDs)
 // and returns the parsed payloads in order. Malformed frames fail the test.
@@ -148,7 +176,7 @@ func TestImportURL_SSE_Headers(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	rw := postImport(t, mux, "/", []string{srv.URL + "/cat.jpg"})
 	if rw.Code != http.StatusOK {
@@ -171,7 +199,7 @@ func TestImportURL_SSE_SingleImage_StartDoneSummary(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	rw := postImport(t, mux, "/", []string{srv.URL + "/cat.jpg"})
 	events := parseSSEEvents(t, rw.Body.String())
@@ -202,7 +230,7 @@ func TestImportURL_SSE_HeaderError_NoStart(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	// page.html → unsupported_content_type rejected before Start fires.
 	rw := postImport(t, mux, "/", []string{srv.URL + "/page.html"})
@@ -226,7 +254,7 @@ func TestImportURL_SSE_Mixed_PartialSuccess(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	rw := postImport(t, mux, "/", []string{
@@ -306,7 +334,7 @@ func TestImportURL_SSE_LargeFile_ProgressEmitted(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	rw := postImport(t, mux, "/", []string{srv.URL + "/big.jpg"})
 	events := parseSSEEvents(t, rw.Body.String())
@@ -335,7 +363,7 @@ func TestImportURL_SSE_AudioSkipsThumbPool(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	rw := postImport(t, mux, "/", []string{srv.URL + "/song.mp3"})
 	events := parseSSEEvents(t, rw.Body.String())
@@ -374,7 +402,7 @@ func TestImportURL_HandlerDisconnect_JobContinues(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close() // drains thumbPool + registry.WaitAll for clean t.TempDir cleanup
 
 	// Cancel the request context after the first frame so we observe a real
@@ -413,7 +441,7 @@ func TestImportURL_HandlerDisconnect_JobContinues(t *testing.T) {
 func TestImportURL_EmptyArray(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	rw := postImport(t, mux, "/", []string{})
 	if rw.Code != http.StatusBadRequest {
@@ -427,7 +455,7 @@ func TestImportURL_EmptyArray(t *testing.T) {
 func TestImportURL_OnlyWhitespace(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	rw := postImport(t, mux, "/", []string{"  ", "\t", ""})
 	if rw.Code != http.StatusBadRequest {
@@ -438,7 +466,7 @@ func TestImportURL_OnlyWhitespace(t *testing.T) {
 func TestImportURL_TooMany(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	urls := make([]string, 51)
 	for i := range urls {
@@ -456,7 +484,7 @@ func TestImportURL_TooMany(t *testing.T) {
 func TestImportURL_PathTraversal(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	rw := postImport(t, mux, "../escape", []string{"https://example.com/x.jpg"})
 	if rw.Code != http.StatusBadRequest {
@@ -467,7 +495,7 @@ func TestImportURL_PathTraversal(t *testing.T) {
 func TestImportURL_PathNotFound(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	rw := postImport(t, mux, "/no-such-dir", []string{"https://example.com/x.jpg"})
 	if rw.Code != http.StatusNotFound {
@@ -478,7 +506,7 @@ func TestImportURL_PathNotFound(t *testing.T) {
 func TestImportURL_MethodNotAllowed(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/import-url?path=/", nil)
 	rw := httptest.NewRecorder()
@@ -491,7 +519,7 @@ func TestImportURL_MethodNotAllowed(t *testing.T) {
 func TestImportURL_InvalidBody(t *testing.T) {
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	Register(mux, root, root, nil)
+	registerImportTest(mux, root)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/import-url?path=/",
 		strings.NewReader("not json"))
@@ -766,7 +794,7 @@ func TestImportURL_AllFailed_StatusIsFailed(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	rw := postImport(t, mux, "/", []string{
@@ -805,7 +833,7 @@ func TestImportURL_Queued_EventEmittedOnce(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	// thumbPool spawns goroutines that write `.thumb/*.jpg` sidecars after
 	// the JPEG import succeeds; without Shutdown they can race with
 	// t.TempDir cleanup and produce "directory not empty" failures.
@@ -868,7 +896,7 @@ func TestImportURL_Serialization_TwoBatches(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close() // drains thumbPool; see TestImportURL_Queued_EventEmittedOnce.
 
 	// Batch A acquires the semaphore and then blocks inside the origin.
@@ -934,7 +962,7 @@ func TestImportURL_Queued_CanceledWhileWaiting(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close() // drains thumbPool; see TestImportURL_Queued_EventEmittedOnce.
 
 	// Batch A holds the semaphore.
@@ -989,7 +1017,7 @@ func TestImportURL_Register_FirstEvent(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	defer h.Close()
 
 	rw := postImport(t, mux, "/", []string{srv.URL + "/cat.jpg"})
@@ -1022,7 +1050,7 @@ func TestImportURL_TooManyJobs(t *testing.T) {
 
 	root := t.TempDir()
 	mux := http.NewServeMux()
-	h := Register(mux, root, root, nil)
+	h := registerImportTest(mux, root)
 	// Pre-filled placeholder jobs have no worker so they would never reach a
 	// terminal state on their own — mark them done before Close so its 5s
 	// WaitAll(grace) returns immediately.

--- a/internal/urlfetch/fetch.go
+++ b/internal/urlfetch/fetch.go
@@ -16,6 +16,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"os"
 	"path"
@@ -31,6 +32,8 @@ const (
 	MaxRedirects = 5
 	// DialTimeout limits TCP connection establishment.
 	DialTimeout = 10 * time.Second
+	// DNSLookupTimeout bounds hostname resolution before each protected dial.
+	DNSLookupTimeout = 5 * time.Second
 
 	// progressByteThreshold and progressTimeThreshold bound how often the
 	// Progress callback fires so a very fast download does not emit thousands
@@ -72,6 +75,7 @@ type Callbacks struct {
 var (
 	errTooManyRedirects = errors.New("too_many_redirects")
 	errInvalidScheme    = errors.New("invalid_scheme")
+	errPrivateNetwork   = errors.New("private_network")
 
 	contentTypeToExt = map[string]string{
 		"image/jpeg":       ".jpg",
@@ -112,18 +116,67 @@ var (
 	}
 )
 
+type clientConfig struct {
+	allowPrivateNetworks bool
+	resolver             Resolver
+}
+
+// ClientOption configures the URL import HTTP client.
+type ClientOption func(*clientConfig)
+
+type secureTransport struct {
+	*http.Transport
+	allowPrivateNetworks bool
+	resolver             Resolver
+}
+
+// AllowPrivateNetworks permits loopback, private, link-local, multicast, and
+// unspecified destination IPs. Production code should not use this; it exists
+// for local-only tests and explicitly trusted deployments.
+func AllowPrivateNetworks() ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.allowPrivateNetworks = true
+	}
+}
+
+// WithResolver overrides DNS resolution for the URL import client. Production
+// callers normally use net.DefaultResolver; tests use this to pin resolution
+// outcomes without relying on real DNS.
+func WithResolver(resolver Resolver) ClientOption {
+	return func(cfg *clientConfig) {
+		cfg.resolver = resolver
+	}
+}
+
 // NewClient returns the http.Client used by Fetch. It enforces a 10s dial
-// timeout, a 5-redirect cap, and refuses any redirect hop whose scheme is
-// not http/https. No cookie jar — auth headers and cookies are never carried
-// over by default. The per-URL total timeout is enforced via context by the
-// caller (see handler/import_url.go) so it can be adjusted at runtime via
-// /api/settings without reconstructing the client.
-func NewClient() *http.Client {
+// timeout, a 5-redirect cap, refuses any redirect hop whose scheme is not
+// http/https, and blocks requests to private network addresses by default.
+// No cookie jar — auth headers and cookies are never carried over by default.
+// The per-URL total timeout is enforced via context by the caller (see
+// handler/import_url.go) so it can be adjusted at runtime via /api/settings
+// without reconstructing the client.
+func NewClient(opts ...ClientOption) *http.Client {
+	var cfg clientConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.resolver == nil {
+		cfg.resolver = net.DefaultResolver
+	}
 	dialer := &net.Dialer{Timeout: DialTimeout}
-	return &http.Client{
+	dialContext := dialer.DialContext
+	if !cfg.allowPrivateNetworks {
+		dialContext = publicOnlyDialContext(dialer, cfg.resolver)
+	}
+	transport := &secureTransport{
 		Transport: &http.Transport{
-			DialContext: dialer.DialContext,
+			DialContext: dialContext,
 		},
+		allowPrivateNetworks: cfg.allowPrivateNetworks,
+		resolver:             cfg.resolver,
+	}
+	return &http.Client{
+		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= MaxRedirects {
 				return errTooManyRedirects
@@ -135,6 +188,105 @@ func NewClient() *http.Client {
 			return nil
 		},
 	}
+}
+
+func clientAllowsPrivateNetworks(client *http.Client) bool {
+	if client == nil {
+		return false
+	}
+	transport, ok := client.Transport.(*secureTransport)
+	return ok && transport.allowPrivateNetworks
+}
+
+func clientResolver(client *http.Client) Resolver {
+	if client == nil {
+		return net.DefaultResolver
+	}
+	transport, ok := client.Transport.(*secureTransport)
+	if !ok || transport.resolver == nil {
+		return net.DefaultResolver
+	}
+	return transport.resolver
+}
+
+func publicOnlyDialContext(dialer *net.Dialer, resolver Resolver) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		ips, err := lookupPublicIPs(ctx, resolver, host)
+		if err != nil {
+			return nil, err
+		}
+		for _, ip := range ips {
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			if ctx.Err() != nil {
+				return nil, err
+			}
+		}
+		return nil, fmt.Errorf("dial %s: no reachable addresses", address)
+	}
+}
+
+// Resolver resolves hostnames for protected URL import dials.
+type Resolver interface {
+	LookupIPAddr(context.Context, string) ([]net.IPAddr, error)
+}
+
+func lookupPublicIPs(ctx context.Context, resolver Resolver, host string) ([]netip.Addr, error) {
+	lookupCtx, cancel := context.WithTimeout(ctx, DNSLookupTimeout)
+	defer cancel()
+	ips, err := resolveHost(lookupCtx, resolver, host)
+	if err != nil {
+		return nil, err
+	}
+	for _, ip := range ips {
+		if isBlockedDestination(ip) {
+			return nil, errPrivateNetwork
+		}
+	}
+	return ips, nil
+}
+
+func resolveHost(ctx context.Context, resolver Resolver, host string) ([]netip.Addr, error) {
+	if ip, err := netip.ParseAddr(host); err == nil {
+		return []netip.Addr{ip.Unmap()}, nil
+	}
+	addrs, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		// Fail closed: partial DNS results that arrive with an error are not
+		// trusted for SSRF decisions.
+		return nil, err
+	}
+	ips := make([]netip.Addr, 0, len(addrs))
+	for _, addr := range addrs {
+		ip, ok := netip.AddrFromSlice(addr.IP)
+		if !ok {
+			continue
+		}
+		ips = append(ips, ip.Unmap())
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("resolve %s: no addresses", host)
+	}
+	return ips, nil
+}
+
+func isBlockedDestination(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	// CGNAT (100.64.0.0/10) is intentionally not covered by IsPrivate and is
+	// treated as publicly routable for this single-user import policy.
+	return !ip.IsValid() ||
+		ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
 }
 
 // Fetch downloads rawURL into destDir (absolute path, caller-validated) and
@@ -183,7 +335,7 @@ func Fetch(ctx context.Context, client *http.Client, rawURL, destDir, relDir str
 
 	rawContentType := resp.Header.Get("Content-Type")
 	if isHLSResponse(rawContentType, parsed.Path) {
-		return fetchHLS(ctx, resp, parsed, rawURL, destDir, relDir, warnings, maxBytes, cb)
+		return fetchHLS(ctx, resp, parsed, rawURL, destDir, relDir, warnings, maxBytes, cb, clientAllowsPrivateNetworks(client), clientResolver(client))
 	}
 
 	// A declared Content-Length above the cap is rejected up front so we
@@ -269,6 +421,9 @@ func classifyHTTPError(err error) *FetchError {
 	}
 	if errors.Is(err, errInvalidScheme) {
 		return &FetchError{Code: "invalid_scheme", Err: err}
+	}
+	if errors.Is(err, errPrivateNetwork) {
+		return &FetchError{Code: "private_network", Err: err}
 	}
 	var ce *x509.CertificateInvalidError
 	var hve x509.HostnameError

--- a/internal/urlfetch/fetch_hls_test.go
+++ b/internal/urlfetch/fetch_hls_test.go
@@ -33,7 +33,7 @@ func TestFetch_HLS_MediaPlaylist_Success(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := Fetch(context.Background(), NewClient(),
+	res, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/"+playlistName, dest, "/movies", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -89,7 +89,7 @@ func TestFetch_HLS_MasterPlaylist_PicksHighestBandwidth(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := Fetch(context.Background(), NewClient(),
+	res, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/master.m3u8", dest, "/movies", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -122,7 +122,7 @@ func TestFetch_HLS_MislabeledContentType_Fallback(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := Fetch(context.Background(), NewClient(),
+	res, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/"+playlistName, dest, "/movies", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -160,7 +160,7 @@ func TestFetch_HLS_UppercaseExtension(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := Fetch(context.Background(), NewClient(),
+	res, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/STREAM.M3U8", dest, "/movies", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -185,7 +185,7 @@ func TestFetch_HLS_PlaylistTooLarge(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := Fetch(context.Background(), NewClient(),
+	_, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/big.m3u8", dest, "/movies", testMaxBytes, nil)
 	if ferr == nil {
 		t.Fatal("expected hls_playlist_too_large error, got nil")
@@ -215,7 +215,7 @@ func TestFetch_HLS_PlaylistExactlyAtCap(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := Fetch(context.Background(), NewClient(),
+	_, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/atcap.m3u8", dest, "/movies", testMaxBytes, nil)
 	if ferr == nil {
 		// Unexpected success means ffmpeg happily consumed an empty media
@@ -244,7 +244,7 @@ func TestFetch_HLS_AudioMpegurl_Fallthrough(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := Fetch(context.Background(), NewClient(),
+	res, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/"+playlistName, dest, "/movies", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -295,7 +295,7 @@ func TestFetch_HLS_VariantFileScheme(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := Fetch(context.Background(), NewClient(),
+	_, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/master.m3u8", dest, "/movies", testMaxBytes, nil)
 	if ferr == nil {
 		t.Fatal("expected invalid_scheme error, got nil")
@@ -324,7 +324,7 @@ func TestFetch_HLS_EmptyPlaylist_FFmpegError(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := Fetch(context.Background(), NewClient(),
+	_, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/empty.m3u8", dest, "/movies", testMaxBytes, nil)
 	if ferr == nil {
 		t.Fatal("expected ffmpeg_error, got nil")
@@ -360,7 +360,7 @@ func TestFetch_HLS_Start_Callback_TotalZero(t *testing.T) {
 	}
 
 	dest := t.TempDir()
-	_, ferr := Fetch(context.Background(), NewClient(),
+	_, ferr := Fetch(context.Background(), NewClient(AllowPrivateNetworks()),
 		srv.URL+"/"+playlistName, dest, "/movies", testMaxBytes, cb)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)

--- a/internal/urlfetch/fetch_test.go
+++ b/internal/urlfetch/fetch_test.go
@@ -41,7 +41,7 @@ func TestFetch_OK_JPEG(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/photo.jpg", dest, "/photos", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -73,7 +73,7 @@ func TestFetch_OK_MP4(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/clip.mp4", dest, "/movies", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -92,7 +92,7 @@ func TestFetch_OK_MP3(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/song.mp3", dest, "/music", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -112,7 +112,7 @@ func TestFetch_ExtensionReplaced_MKV(t *testing.T) {
 
 	dest := t.TempDir()
 	// URL declares .mp4 but the server returns MKV; extension must flip to .mkv.
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/clip.mp4", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -135,7 +135,7 @@ func TestFetch_DefaultName_Video(t *testing.T) {
 
 	dest := t.TempDir()
 	// URL path is "/" so there is no usable basename.
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -151,7 +151,7 @@ func TestFetch_DefaultName_Audio(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -163,7 +163,7 @@ func TestFetch_DefaultName_Audio(t *testing.T) {
 
 func TestFetch_InvalidScheme(t *testing.T) {
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		"file:///etc/passwd", dest, "/", testMaxBytes, nil)
 	if ferr == nil || ferr.Code != "invalid_scheme" {
 		t.Fatalf("got %v, want invalid_scheme", ferr)
@@ -172,7 +172,7 @@ func TestFetch_InvalidScheme(t *testing.T) {
 
 func TestFetch_InvalidURL(t *testing.T) {
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		"://no-scheme", dest, "/", testMaxBytes, nil)
 	if ferr == nil || ferr.Code != "invalid_url" {
 		t.Fatalf("got %v, want invalid_url", ferr)
@@ -194,7 +194,7 @@ func TestFetch_NoContentLength_Succeeds(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/photo.jpg", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -215,7 +215,7 @@ func TestFetch_ContentLengthTooLarge(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/big.jpg", dest, "/", cap, nil)
 	if ferr == nil || ferr.Code != "too_large" {
 		t.Fatalf("got %v, want too_large", ferr)
@@ -241,7 +241,7 @@ func TestFetch_NoContentLength_RuntimeCap(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/over.jpg", dest, "/", cap, nil)
 	if ferr == nil || ferr.Code != "too_large" {
 		t.Fatalf("got %v, want too_large", ferr)
@@ -255,7 +255,7 @@ func TestFetch_UnsupportedContentType(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/page.html", dest, "/", testMaxBytes, nil)
 	if ferr == nil || ferr.Code != "unsupported_content_type" {
 		t.Fatalf("got %v, want unsupported_content_type", ferr)
@@ -269,7 +269,7 @@ func TestFetch_ExtensionMismatch_Replaced(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/cat.jpg", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -288,7 +288,7 @@ func TestFetch_NoExtensionInURL(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/photo", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -308,7 +308,7 @@ func TestFetch_ExtensionEquivalent_NoWarning(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/photo.jpeg", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -330,7 +330,7 @@ func TestFetch_RedirectCap(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/start", dest, "/", testMaxBytes, nil)
 	if ferr == nil || ferr.Code != "too_many_redirects" {
 		t.Fatalf("got %v, want too_many_redirects", ferr)
@@ -344,7 +344,7 @@ func TestFetch_HTTP404(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/missing.jpg", dest, "/", testMaxBytes, nil)
 	if ferr == nil || ferr.Code != "http_error" {
 		t.Fatalf("got %v, want http_error", ferr)
@@ -358,7 +358,7 @@ func TestFetch_FilenameSanitize_DotDot(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/a/..", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -383,7 +383,7 @@ func TestFetch_Collision_RenamesUnique(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/photo.jpg", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -407,7 +407,7 @@ func TestFetch_TempFileCleaned_OnRejection(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/x.txt", dest, "/", testMaxBytes, nil)
 	if ferr == nil {
 		t.Fatal("expected failure")
@@ -423,7 +423,7 @@ func TestFetch_ExtensionReplaced_FromNonImageExt(t *testing.T) {
 	defer srv.Close()
 
 	dest := t.TempDir()
-	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	res, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/blob.bin", dest, "/", testMaxBytes, nil)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -449,7 +449,7 @@ func TestFetch_Start_Called_WithNameTotalType(t *testing.T) {
 		},
 	}
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/clip.mp4", dest, "/", testMaxBytes, cb)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -477,7 +477,7 @@ func TestFetch_Progress_Emitted_ForLargePayload(t *testing.T) {
 	}
 
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/big.jpg", dest, "/", testMaxBytes, cb)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -510,7 +510,7 @@ func TestFetch_Progress_NotEmitted_ForTinyPayload(t *testing.T) {
 	}
 
 	dest := t.TempDir()
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/tiny.jpg", dest, "/", testMaxBytes, cb)
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)
@@ -528,7 +528,7 @@ func TestFetch_Progress_NilCallback_OK(t *testing.T) {
 
 	dest := t.TempDir()
 	// Explicit zero-value Callbacks — both fields nil.
-	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(),
+	_, ferr := urlfetch.Fetch(context.Background(), urlfetch.NewClient(urlfetch.AllowPrivateNetworks()),
 		srv.URL+"/any.jpg", dest, "/", testMaxBytes, &urlfetch.Callbacks{})
 	if ferr != nil {
 		t.Fatalf("fetch failed: %v", ferr)

--- a/internal/urlfetch/hls.go
+++ b/internal/urlfetch/hls.go
@@ -142,6 +142,11 @@ func parseMasterPlaylist(body []byte, base *url.URL) (*url.URL, error) {
 	return resolved, nil
 }
 
+func validatePublicURL(ctx context.Context, resolver Resolver, u *url.URL) error {
+	_, err := lookupPublicIPs(ctx, resolver, u.Hostname())
+	return err
+}
+
 // sameURL compares two URLs by scheme/host/path — query/fragment ignored — so
 // a variant link with a differing token still counts as the same endpoint for
 // loop detection.
@@ -261,6 +266,8 @@ func fetchHLS(
 	warnings []string,
 	maxBytes int64,
 	cb *Callbacks,
+	allowPrivateNetworks bool,
+	resolver Resolver,
 ) (*Result, *FetchError) {
 	body, err := io.ReadAll(io.LimitReader(resp.Body, hlsMaxPlaylistBytes+1))
 	if err != nil {
@@ -279,6 +286,14 @@ func fetchHLS(
 			return nil, &FetchError{Code: "invalid_scheme", Err: err}
 		}
 		return nil, &FetchError{Code: "ffmpeg_error", Err: err}
+	}
+	if !allowPrivateNetworks {
+		if err := validatePublicURL(ctx, resolver, variantURL); err != nil {
+			if errors.Is(err, errPrivateNetwork) {
+				return nil, &FetchError{Code: "private_network", Err: err}
+			}
+			return nil, &FetchError{Code: "ffmpeg_error", Err: err}
+		}
 	}
 
 	name := deriveHLSFilename(parsed)

--- a/internal/urlfetch/private_network_test.go
+++ b/internal/urlfetch/private_network_test.go
@@ -1,0 +1,91 @@
+package urlfetch
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsBlockedDestination(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{"loopback v4", "127.0.0.1", true},
+		{"loopback v6", "::1", true},
+		{"private 10/8", "10.1.2.3", true},
+		{"private 172.16/12", "172.20.1.1", true},
+		{"private 192.168/16", "192.168.1.1", true},
+		{"link local", "169.254.10.20", true},
+		{"unspecified", "0.0.0.0", true},
+		{"multicast", "224.0.0.1", true},
+		{"public v4", "8.8.8.8", false},
+		{"public v6", "2001:4860:4860::8888", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := netip.MustParseAddr(tt.ip)
+			if got := isBlockedDestination(ip); got != tt.want {
+				t.Fatalf("isBlockedDestination(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+type fakeResolver struct {
+	addrs []string
+	err   error
+}
+
+func (r fakeResolver) LookupIPAddr(context.Context, string) ([]net.IPAddr, error) {
+	out := make([]net.IPAddr, 0, len(r.addrs))
+	for _, raw := range r.addrs {
+		out = append(out, net.IPAddr{IP: net.ParseIP(raw)})
+	}
+	return out, r.err
+}
+
+func TestLookupPublicIPs_BlocksIfAnyAddressIsPrivate(t *testing.T) {
+	resolver := fakeResolver{addrs: []string{"8.8.8.8", "127.0.0.1"}}
+	_, err := lookupPublicIPs(context.Background(), resolver, "mixed.example")
+	if !errors.Is(err, errPrivateNetwork) {
+		t.Fatalf("got %v, want errPrivateNetwork", err)
+	}
+}
+
+func TestResolveHost_FailsClosedOnPartialResolverError(t *testing.T) {
+	resolver := fakeResolver{
+		addrs: []string{"8.8.8.8"},
+		err:   errors.New("partial DNS failure"),
+	}
+	ips, err := resolveHost(context.Background(), resolver, "partial.example")
+	if err == nil {
+		t.Fatal("expected resolver error")
+	}
+	if len(ips) != 0 {
+		t.Fatalf("ips = %v, want none when resolver returns an error", ips)
+	}
+}
+
+func TestFetch_BlocksPrivateNetworkByDefault(t *testing.T) {
+	dest := t.TempDir()
+	_, ferr := Fetch(context.Background(), NewClient(),
+		"http://127.0.0.1/photo.jpg", dest, "/", int64(4)<<30, nil)
+	if ferr == nil || ferr.Code != "private_network" {
+		t.Fatalf("got %v, want private_network", ferr)
+	}
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".urlimport-") {
+			t.Fatalf("leftover temp file: %s", e.Name())
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- block URL imports to loopback/private/link-local/multicast/unspecified IP destinations by default
- use resolve -> validate -> IP-literal dial for normal HTTP URL imports
- pre-validate selected HLS variant URLs before invoking ffmpeg, with HLS DNS rebinding limitation documented
- add test-only URL client override/resolver injection for localhost origins and deterministic DNS tests
- document private_network errors and the HLS follow-up boundary

## Follow-up
- Strong HLS SSRF hardening is split to #5 because ffmpeg performs its own DNS resolution for variant/segment fetches.

## Tests
- GOCACHE=/tmp/go-build-file-server-ssrf go test ./...